### PR TITLE
Resolves nginx output var diffs from kubernetes 2.5

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -4,9 +4,9 @@ output "ingress_class" {
 }
 
 output "nginx_url" {
-  value = "http://${data.kubernetes_service.status.load_balancer.0.ingress.ip}"
+  value = "http://${data.kubernetes_service.nginx.status.load_balancer.0.ingress.ip}"
 }
 
 output "load_balancer_ip" {
-  value = data.kubernetes_service.status.load_balancer.0.ingress.ip
+  value = data.kubernetes_service.nginx.status.load_balancer.0.ingress.ip
 }

--- a/output.tf
+++ b/output.tf
@@ -4,9 +4,9 @@ output "ingress_class" {
 }
 
 output "nginx_url" {
-  value = "http://${data.kubernetes_service.nginx.status.load_balancer.0.ingress.ip}"
+  value = "http://${data.kubernetes_service.nginx.status.0.load_balancer.0.ingress.0.ip}"
 }
 
 output "load_balancer_ip" {
-  value = data.kubernetes_service.nginx.status.load_balancer.0.ingress.ip
+  value = data.kubernetes_service.nginx.status.0.load_balancer.0.ingress.0.ip
 }

--- a/output.tf
+++ b/output.tf
@@ -4,9 +4,9 @@ output "ingress_class" {
 }
 
 output "nginx_url" {
-  value = "http://${data.kubernetes_service.nginx.load_balancer_ingress.0.ip}"
+  value = "http://${data.kubernetes_service.status.load_balancer.0.ingress.ip}"
 }
 
 output "load_balancer_ip" {
-  value = data.kubernetes_service.nginx.load_balancer_ingress.0.ip
+  value = data.kubernetes_service.status.load_balancer.0.ingress.ip
 }

--- a/providers.tf
+++ b/providers.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">=2.1.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~>2.5"
+    }
   }
 }


### PR DESCRIPTION
Starting in what seems to be hashicorp/kubernetes provider 2.5, the kubernetes_service data source has changed its output variables from `data.kubernetes_service.nginx.load_balancer_ingress.*` to `data.kubernetes_service.nginx.status.*`. The proposed changes fix the "nginx_url" and "load_balancer_ip" outputs to use the correct properties of the updated data source.

Additionally, a proposed change includes a versioned hashicorp/kubernetes provider block for stability and clarity to end-users.